### PR TITLE
Group orders by date with headers

### DIFF
--- a/app/src/main/java/com/example/ezpos/fragments/HistorialFragment.java
+++ b/app/src/main/java/com/example/ezpos/fragments/HistorialFragment.java
@@ -135,6 +135,14 @@ public class HistorialFragment extends Fragment {
 
     private void mostrarPedidosFiltrados(String filtro) {
         listaHistorial.removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(requireContext());
+        SimpleDateFormat formatoEntrada = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
+        SimpleDateFormat formatoDia = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+        SimpleDateFormat formatoCabecera = new SimpleDateFormat("dd 'de' MMMM yyyy", Locale.getDefault());
+
+        String ultimoDia = "";
+
         for (Pedido p : pedidos) {
             boolean pasaFiltroTexto = p.getNombreCliente().toLowerCase().contains(filtro.toLowerCase());
 
@@ -156,6 +164,28 @@ public class HistorialFragment extends Fragment {
             }
 
             if (pasaFiltroTexto && pasaFiltroFecha) {
+                try {
+                    Date fecha = formatoEntrada.parse(p.getFechaHora());
+                    String diaActual = formatoDia.format(fecha);
+
+                    if (!diaActual.equals(ultimoDia)) {
+                        ultimoDia = diaActual;
+                        TextView header = (TextView) inflater.inflate(R.layout.item_fecha_header, listaHistorial, false);
+                        Calendar hoy = Calendar.getInstance();
+                        Calendar calPedido = Calendar.getInstance();
+                        calPedido.setTime(fecha);
+                        if (calPedido.get(Calendar.YEAR) == hoy.get(Calendar.YEAR) &&
+                                calPedido.get(Calendar.DAY_OF_YEAR) == hoy.get(Calendar.DAY_OF_YEAR)) {
+                            header.setText(getString(R.string.label_today));
+                        } else {
+                            header.setText(formatoCabecera.format(fecha));
+                        }
+                        listaHistorial.addView(header);
+                    }
+                } catch (ParseException e) {
+                    // Ignorar errores de formato y no mostrar cabecera
+                }
+
                 listaHistorial.addView(crearCardPedido(p));
             }
         }

--- a/app/src/main/java/com/example/ezpos/fragments/PedidosFragment.java
+++ b/app/src/main/java/com/example/ezpos/fragments/PedidosFragment.java
@@ -120,6 +120,14 @@ public class PedidosFragment extends Fragment {
         listaPedidos.removeAllViews();
         String filtro = texto.toLowerCase();
 
+        LayoutInflater inflater = LayoutInflater.from(requireContext());
+        SimpleDateFormat formatoEntrada = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
+        SimpleDateFormat formatoSalida = new SimpleDateFormat("dd-MM-yyyy HH:mm", Locale.getDefault());
+        SimpleDateFormat formatoDia = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+        SimpleDateFormat formatoCabecera = new SimpleDateFormat("dd 'de' MMMM yyyy", Locale.getDefault());
+
+        String ultimoDia = "";
+
         for (Pedido pedido : listaCompletaPedidos) {
             if (pedido.getNombreCliente().toLowerCase().contains(filtro)) {
                 View cardView = LayoutInflater.from(requireContext()).inflate(R.layout.item_pedido, listaPedidos, false);
@@ -130,10 +138,9 @@ public class PedidosFragment extends Fragment {
                 TextView tvDevolver = cardView.findViewById(R.id.tvADevolverPedido);
 
                 String fechaFormateada;
+                Date fecha = null;
                 try {
-                    SimpleDateFormat formatoEntrada = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault());
-                    SimpleDateFormat formatoSalida = new SimpleDateFormat("dd-MM-yyyy HH:mm", Locale.getDefault());
-                    Date fecha = formatoEntrada.parse(pedido.getFechaHora());
+                    fecha = formatoEntrada.parse(pedido.getFechaHora());
                     fechaFormateada = formatoSalida.format(fecha);
                 } catch (ParseException e) {
                     fechaFormateada = pedido.getFechaHora(); // en caso de error
@@ -148,6 +155,24 @@ public class PedidosFragment extends Fragment {
                     tvDevolver.setTextColor(getResources().getColor(android.R.color.holo_green_dark));
                 } else {
                     tvDevolver.setTextColor(getResources().getColor(android.R.color.holo_red_dark));
+                }
+
+                if (fecha != null) {
+                    String diaActual = formatoDia.format(fecha);
+                    if (!diaActual.equals(ultimoDia)) {
+                        ultimoDia = diaActual;
+                        TextView header = (TextView) inflater.inflate(R.layout.item_fecha_header, listaPedidos, false);
+                        Calendar hoy = Calendar.getInstance();
+                        Calendar calPedido = Calendar.getInstance();
+                        calPedido.setTime(fecha);
+                        if (calPedido.get(Calendar.YEAR) == hoy.get(Calendar.YEAR) &&
+                                calPedido.get(Calendar.DAY_OF_YEAR) == hoy.get(Calendar.DAY_OF_YEAR)) {
+                            header.setText(getString(R.string.label_today));
+                        } else {
+                            header.setText(formatoCabecera.format(fecha));
+                        }
+                        listaPedidos.addView(header);
+                    }
                 }
 
                 listaPedidos.addView(cardView);

--- a/app/src/main/res/layout/item_fecha_header.xml
+++ b/app/src/main/res/layout/item_fecha_header.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tvFechaHeader"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="12dp"
+    android:paddingBottom="4dp"
+    android:text="Fecha"
+    android:textStyle="bold"
+    android:textSize="16sp"
+    android:textColor="?attr/colorOnBackground" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="intro_agregar_producto">Introduce la informaci\u00f3n del producto y guarda.</string>
     <string name="intro_registro">Crea tu cuenta rellenando todos los campos y pulsa Registrarse.</string>
     <string name="intro_resumen_pedido">Revisa los detalles del pedido y registra el pago o entrega.</string>
+    <string name="label_today">Hoy</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a layout for date headers
- display date headers in `HistorialFragment` and `PedidosFragment`
- add `label_today` string for "Hoy"

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684146be81308325a192f55a3745fe30