### PR TITLE
Validate date range in history

### DIFF
--- a/app/src/main/java/com/example/ezpos/fragments/HistorialFragment.java
+++ b/app/src/main/java/com/example/ezpos/fragments/HistorialFragment.java
@@ -288,9 +288,17 @@ public class HistorialFragment extends Fragment {
                     SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy", Locale.getDefault());
 
                     if (esDesde) {
+                        if (fechaHasta != null && seleccionada.after(fechaHasta)) {
+                            Toast.makeText(requireContext(), R.string.error_fecha_desde_posterior, Toast.LENGTH_SHORT).show();
+                            return;
+                        }
                         fechaDesde = seleccionada;
                         fechaDesdeText.setText(sdf.format(seleccionada.getTime()));
                     } else {
+                        if (fechaDesde != null && seleccionada.before(fechaDesde)) {
+                            Toast.makeText(requireContext(), R.string.error_fecha_hasta_anterior, Toast.LENGTH_SHORT).show();
+                            return;
+                        }
                         fechaHasta = seleccionada;
                         seleccionada.set(Calendar.HOUR_OF_DAY, 23);
                         seleccionada.set(Calendar.MINUTE, 59);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
     <string name="intro_registro">Crea tu cuenta rellenando todos los campos y pulsa Registrarse.</string>
     <string name="intro_resumen_pedido">Revisa los detalles del pedido y registra el pago o entrega.</string>
     <string name="label_today">Hoy</string>
+    <string name="error_fecha_hasta_anterior">La fecha Hasta no puede ser anterior a la fecha Desde</string>
+    <string name="error_fecha_desde_posterior">La fecha Desde no puede ser posterior a la fecha Hasta</string>
 </resources>


### PR DESCRIPTION
## Summary
- prevent selecting invalid date ranges when filtering History
- show toast messages if "Hasta" is before "Desde" or vice versa
- add Spanish strings for the new error messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416acb5fd48325b902da576bf75847