### PR TITLE
Display daily earnings in history

### DIFF
--- a/app/src/main/res/layout/item_fecha_header.xml
+++ b/app/src/main/res/layout/item_fecha_header.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/tvFechaHeader"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="horizontal"
     android:paddingTop="12dp"
     android:paddingBottom="4dp"
-    android:text="Fecha"
-    android:textStyle="bold"
-    android:textSize="16sp"
-    android:textColor="?attr/colorOnBackground" />
+    android:gravity="center_vertical">
+
+    <TextView
+        android:id="@+id/tvFechaHeader"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Fecha"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        android:textColor="?attr/colorOnBackground" />
+
+    <TextView
+        android:id="@+id/tvGananciasDia"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="0€"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        android:textColor="?attr/colorOnBackground" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- show daily earnings next to each date header in the history fragment
- recalculate totals per day when loading data
- refresh history on resume
- update header layout to include an earnings label

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418047b6ec83258237b6ee67bcbab9