### PR TITLE
Improve database import handling

### DIFF
--- a/app/src/main/java/com/example/ezpos/database/EZPOSSQLiteHelper.java
+++ b/app/src/main/java/com/example/ezpos/database/EZPOSSQLiteHelper.java
@@ -9,11 +9,14 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 public class EZPOSSQLiteHelper extends SQLiteOpenHelper {
 
+    // Versión actual del esquema de la base de datos
+    public static final int DB_VERSION = 9;
+
     /**
      * Recibe el nombre de la base para cada usuario y versiona el esquema.
      */
     public EZPOSSQLiteHelper(Context context, String nombreDB) {
-        super(context, nombreDB, null, 9);
+        super(context, nombreDB, null, DB_VERSION);
     }
 
     @Override

--- a/app/src/main/java/com/example/ezpos/fragments/InventarioFragment.java
+++ b/app/src/main/java/com/example/ezpos/fragments/InventarioFragment.java
@@ -37,7 +37,6 @@ import com.example.ezpos.IntroHelper;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -151,21 +150,8 @@ public class InventarioFragment extends Fragment {
                     if (result.getResultCode() == getActivity().RESULT_OK && result.getData() != null) {
                         Uri uri = result.getData().getData();
                         try {
-                            String dbName = DatabaseUtils.getNombreBaseDatos(requireContext());
-                            File dbFile = requireContext().getDatabasePath(dbName);
-
-                            // Cerrar la base de datos antes de reemplazarla para evitar bloqueos
-                            DatabaseUtils.getDatabaseHelper(requireContext()).close();
-
                             InputStream in = requireContext().getContentResolver().openInputStream(uri);
-                            OutputStream out = new FileOutputStream(dbFile);
-                            byte[] buffer = new byte[1024];
-                            int length;
-                            while ((length = in.read(buffer)) > 0) {
-                                out.write(buffer, 0, length);
-                            }
-                            in.close();
-                            out.close();
+                            DatabaseUtils.reemplazarBaseDatos(requireContext(), in);
                             Toast.makeText(requireContext(), "Base de datos importada correctamente", Toast.LENGTH_SHORT).show();
                             mostrarProductos();
                         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- define `DB_VERSION` in `EZPOSSQLiteHelper`
- add `reemplazarBaseDatos` helper to overwrite the current DB
- use the new helper in `InventarioFragment`

## Testing
- `./gradlew help`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1954b2648325b87ac2610e6d7482